### PR TITLE
add async-utils-finagle-natchez, introducing TracedThriftServer and TracedThriftClient

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -81,11 +81,11 @@ jobs:
 
       - name: Make target directories
         if: github.event_name != 'pull_request' && (startsWith(github.ref, 'refs/tags/v') || github.ref == 'refs/heads/main')
-        run: mkdir -p twitter-futures/target scalafix/output/target scalafix/input/target twitter-finagle/target scalafix/output-dependency/target scalafix/rules/target target scalafix/input-dependency/target scalafix/tests/target project/target
+        run: mkdir -p twitter-futures/target scalafix/output/target scalafix/input/target twitter-finagle/target scalafix/output-dependency/target finagle-natchez/target scalafix/rules/target target scalafix/input-dependency/target scalafix/tests/target project/target
 
       - name: Compress target directories
         if: github.event_name != 'pull_request' && (startsWith(github.ref, 'refs/tags/v') || github.ref == 'refs/heads/main')
-        run: tar cf targets.tar twitter-futures/target scalafix/output/target scalafix/input/target twitter-finagle/target scalafix/output-dependency/target scalafix/rules/target target scalafix/input-dependency/target scalafix/tests/target project/target
+        run: tar cf targets.tar twitter-futures/target scalafix/output/target scalafix/input/target twitter-finagle/target scalafix/output-dependency/target finagle-natchez/target scalafix/rules/target target scalafix/input-dependency/target scalafix/tests/target project/target
 
       - name: Upload target directories
         if: github.event_name != 'pull_request' && (startsWith(github.ref, 'refs/tags/v') || github.ref == 'refs/heads/main')

--- a/.mergify.yml
+++ b/.mergify.yml
@@ -14,6 +14,14 @@ pull_request_rules:
   - status-success=Build and Test (ubuntu-latest, 2.12, temurin@8)
   actions:
     merge: {}
+- name: Label finagle-natchez PRs
+  conditions:
+  - files~=^finagle-natchez/
+  actions:
+    label:
+      add:
+      - finagle-natchez
+      remove: []
 - name: Label input PRs
   conditions:
   - files~=^scalafix/input/

--- a/build.sbt
+++ b/build.sbt
@@ -65,6 +65,19 @@ lazy val `async-utils-finagle` = project
   )
   .dependsOn(`async-utils-twitter`)
 
+lazy val `async-utils-finagle-natchez` = project
+  .in(file("finagle-natchez"))
+  .settings(
+    crossScalaVersions := Scala2Versions,
+    libraryDependencies ++= {
+      Seq(
+        "org.tpolecat" %% "natchez-core" % "0.1.6",
+        "com.comcast" %% "ip4s-core" % "3.2.0",
+      ) ++ (if (scalaVersion.value.startsWith("2")) scala2CompilerPlugins else Nil)
+    }
+  )
+  .dependsOn(`async-utils-finagle`)
+
 lazy val `scalafix-rules` = project
   .in(file("scalafix/rules"))
   .settings(
@@ -164,6 +177,7 @@ lazy val `async-utils-root` = (project in file("."))
   .aggregate(
     `async-utils-twitter`,
     `async-utils-finagle`,
+    `async-utils-finagle-natchez`,
     `scalafix-rules`,
     `scalafix-tests`,
   )

--- a/finagle-natchez/src/main/scala/com/dwolla/util/async/finagle/TracedThriftClient.scala
+++ b/finagle-natchez/src/main/scala/com/dwolla/util/async/finagle/TracedThriftClient.scala
@@ -1,0 +1,80 @@
+package com.dwolla.util.async.finagle
+
+import cats.data._
+import cats.effect.{Trace => _, tracing => _, _}
+import cats.syntax.all._
+import cats.tagless._
+import com.dwolla.util.async.finagle.ThriftClient.initialAcquire
+import com.dwolla.util.async.twitter._
+import com.twitter.util.{Closable, Future}
+import natchez.Trace
+
+import scala.language.reflectiveCalls
+
+/**
+ * Build a Finagle Thrift client using the given Thrift
+ * method-per-endpoint algebra and the given destination. Optionally,
+ * configure the client by setting options on a
+ * `ThriftClientConfiguration` object passed to `apply`. The client
+ * will propagate spans from the ambient `Trace[G]` using Finagle's
+ * built-in Zipkin support.
+ */
+object TracedThriftClient {
+  /**
+   * Builds a Finagle client safely translated from Twitter Future to
+   * the given `G[_] : Async` effect type, with trace propagation from
+   * the ambient `Trace[G]` to Finagle's Zipkin support. The lifecycle
+   * of the client is managed in a Cats Effect `Resource`.
+   *
+   * This method is partially applied; the instance returned accepts
+   * several more parameters. It's implemented this way because the
+   * caller must specify the `Alg` parameter, but the other type
+   * parameters are normally able to be inferred and therefore not
+   * explicitly set. See the `PartiallyAppliedThriftClient.apply`
+   * Scaladoc for more details on the additional parameters.
+   *
+   * @tparam Alg the method-per-endpoint trait on which to base the Finagle client
+   * @return a Finagle Thrift client that will operate in
+   */
+  def apply[Alg[_[_]] <: AnyRef {def asClosable: Closable}] = new PartiallyAppliedThriftClient[Alg]()
+
+  class PartiallyAppliedThriftClient[Alg[_[_]] <: AnyRef {def asClosable: Closable}] private[TracedThriftClient](val dummy: Unit = ()) extends AnyVal {
+    /**
+     * @param dest the destination whence the Thrift interface is being served.
+     *             supports Finagle's `Resolver` interface (because the destination
+     *             is handed directly to the Finagle layer)
+     * @tparam F the effect type in which to construct the Resource that will manage the client. Requires an `Async` instance, but not a `Trace`
+     * @tparam G the effect type in which the client should operate. Requires both an `Async` and `Trace` constraint.
+     * @return a Finagle Thrift client that will operate in
+     */
+    def apply[F[_] : Async, G[_] : Async : Trace](dest: String)
+                                                 (implicit
+                                                  AlgR: Alg[Kleisli[Future, Alg[Future], *]],
+                                                  FK: FunctorK[Alg],
+                                                  MPE: HigherKindedToMethodPerEndpoint[Alg],
+                                                 ): Resource[F, Alg[G]] =
+      apply[F, G](dest, ThriftClientConfiguration())
+
+    /**
+     * @param dest the destination whence the Thrift interface is being served.
+     *             supports Finagle's `Resolver` interface (because the destination
+     *             is handed directly to the Finagle layer)
+     * @param config an instance of `ThriftClientConfiguration` containing configuration settings
+     * @tparam F the effect type in which to construct the Resource that will manage the client. Requires an `Async` instance, but not a `Trace`
+     * @tparam G the effect type in which the client should operate. Requires both an `Async` and `Trace` constraint.
+     * @return a Finagle Thrift client that will operate in
+     */
+    def apply[F[_] : Async, G[_] : Async : Trace](dest: String,
+                                                  config: ThriftClientConfiguration)
+                                                 (implicit
+                                                  AlgR: Alg[Kleisli[Future, Alg[Future], *]],
+                                                  FK: FunctorK[Alg],
+                                                  HK2MPE: HigherKindedToMethodPerEndpoint[Alg],
+                                                 ): Resource[F, Alg[G]] = {
+      val acquire = initialAcquire[Alg, F](dest, config).map(TracedTwitterFutureAsyncFunctorK[G].asyncMapK[Alg])
+      val release: Alg[G] => F[Unit] = alg => liftFuture(Sync[F].delay(alg.asClosable.close()))
+
+      Resource.make(acquire)(release)
+    }
+  }
+}

--- a/finagle-natchez/src/main/scala/com/dwolla/util/async/finagle/TracedThriftServer.scala
+++ b/finagle-natchez/src/main/scala/com/dwolla/util/async/finagle/TracedThriftServer.scala
@@ -1,0 +1,102 @@
+package com.dwolla.util.async.finagle
+
+import cats._
+import cats.data.Kleisli
+import cats.effect._
+import cats.effect.std.Dispatcher
+import cats.syntax.all._
+import cats.tagless._
+import cats.tagless.aop._
+import cats.tagless.implicits._
+import com.comcast.ip4s.{IpAddress, SocketAddress}
+import com.dwolla.util.async.finagle.HigherKindedToMethodPerEndpoint._
+import com.dwolla.util.async.twitter._
+import com.twitter.finagle._
+import com.twitter.finagle.tracing.TraceId
+import com.twitter.util._
+import natchez._
+
+import scala.concurrent.ExecutionContext
+import scala.util.{Failure, Success}
+
+/**
+ * Starts a Finagle server that will host the given Thrift
+ * method-per-endpoint implementation.
+ */
+object TracedThriftServer {
+  /**
+   *
+   * @param addr the socket address at which to listen for connections. (Typically `0.0.0.0:port`)
+   * @param label the name to assign the service in the Zipkin traces
+   * @param iface the Thrift method-per-endpoint implementation. Must be implemented in `Kleisli[F, Span[F], *]` so the span continued from Zipkin can be injected into the program.
+   * @param entryPoint the Natchez `EntryPoint` responsible for creating `Span` instances based on the Trace IDs coming from Finagle/Zipkin
+   * @tparam Thrift
+   * @return a `Resource[F, ListeningServer]` managing the lifecycle of the underlying Finagle server
+   */
+  def apply[F[_] : Async, Thrift[_[_]] : HigherKindedToMethodPerEndpoint : Instrument](addr: SocketAddress[IpAddress],
+                                                                                       label: String,
+                                                                                       iface: Thrift[Kleisli[F, Span[F], *]],
+                                                                                       entryPoint: EntryPoint[F]
+                                                                                      )
+                                                                                      (implicit ec: ExecutionContext): Resource[F, ListeningServer] =
+    Dispatcher.parallel[F]
+      .map(unsafeMapKToFuture(_, iface.instrument, entryPoint))
+      .flatMap(t => Resource.make(acquire(addr, label, t))(release[F]))
+
+  private def unsafeMapKToFuture[F[_] : Async, Thrift[_[_]] : FunctorK](dispatcher: Dispatcher[F],
+                                                                        iface: Thrift[Instrumentation[Kleisli[F, Span[F], *], *]],
+                                                                        entryPoint: EntryPoint[F],
+                                                                       )
+                                                                       (implicit ec: ExecutionContext): Thrift[Future] =
+    iface.mapK(new (Instrumentation[Kleisli[F, Span[F], *], *] ~> Future) {
+      override def apply[A](fa: Instrumentation[Kleisli[F, Span[F], *], A]): Future[A] =
+        currentTraceId().flatMap { maybeTraceId =>
+          val p = Promise[A]()
+
+          dispatcher.unsafeToFuture {
+            entryPoint.continueOrElseRoot(
+              s"${fa.algebraName}.${fa.methodName}",
+              maybeTraceId
+                .map(toZipkinKernel)
+                .getOrElse(Kernel(Map.empty))
+            )
+              .use(fa.value.run)
+          }
+            .onComplete {
+              case Success(a) => p.setValue(a)
+              case Failure(ex) => p.setException(ex)
+            }
+
+          p
+        }
+    })
+
+  private def currentTraceId(): Future[Option[TraceId]] =
+    Future(com.twitter.finagle.tracing.Trace.idOption)
+
+  // TODO this propagates the headers in the B3 format, but maybe it should convert to OpenTelemetry / W3C's tracecontext header
+  private def toZipkinKernel(t: TraceId): Kernel = Kernel {
+    val headers: List[(String, String)] =
+      List(
+        "X-B3-TraceId" -> t.traceId.toString(),
+        "X-B3-SpanId" -> t.spanId.toString(),
+      ) ++
+        t._parentId.map(_.toString).map("X-B3-ParentSpanId" -> _).toList ++
+        t.sampled.ifM(Option("X-B3-Sampled" -> "1"), None).toList
+
+    headers.toMap
+  }
+
+  private def acquire[F[_] : Sync, Thrift[_[_]] : HigherKindedToMethodPerEndpoint](addr: SocketAddress[IpAddress],
+                                                                                   label: String,
+                                                                                   iface: Thrift[Future]): F[ListeningServer] =
+    Sync[F].delay {
+      Thrift
+        .server
+        .withLabel(label)
+        .serveIface(addr.toInetSocketAddress, iface.toMethodPerEndpoint)
+    }
+
+  private def release[F[_] : Async](s: ListeningServer): F[Unit] =
+    liftFuture(Sync[F].delay(s.close()))
+}

--- a/finagle-natchez/src/main/scala/com/dwolla/util/async/finagle/TracedTwitterFutureAsyncFunctorK.scala
+++ b/finagle-natchez/src/main/scala/com/dwolla/util/async/finagle/TracedTwitterFutureAsyncFunctorK.scala
@@ -1,0 +1,66 @@
+package com.dwolla.util.async.finagle
+
+import cats._
+import cats.data._
+import cats.effect.{Trace => _, _}
+import cats.syntax.all._
+import cats.tagless._
+import cats.tagless.syntax.all._
+import com.dwolla.util.async.finagle.TracedTwitterFutureAsyncFunctorK.ProvideFutureAlgWithTracing
+import com.dwolla.util.async.twitter._
+import com.dwolla.util.async.~~>
+import com.twitter.finagle
+import com.twitter.finagle.tracing.{SpanId, TraceId}
+import com.twitter.util.Future
+import natchez.Kernel
+
+object TracedTwitterFutureAsyncFunctorK {
+  def apply[F[_] : natchez.Trace]: TracedTwitterFutureAsyncFunctorK[F] =
+    new TracedTwitterFutureAsyncFunctorK[F]
+
+  class ProvideFutureAlgWithTracing[F[_] : Async : natchez.Trace, Alg[_[_]]](alg: Alg[Future]) extends (Kleisli[Future, Alg[Future], *] ~> F) {
+    override def apply[A](fa: Kleisli[Future, Alg[Future], A]): F[A] =
+      OptionT(natchez.Trace[F].kernel.map(zipkinKernelToTraceId))
+        .semiflatMap { traceId =>
+          liftFuture[F] {
+            Sync[F].delay {
+              // TODO check Trace.isActivelyTracing?
+              finagle.tracing.Trace.letId(traceId) {
+                // finally provide the algebra instance to the Kleisli implementation
+                // this is safe because it's captured by a Sync[F].delay
+                fa(alg)
+              }
+            }
+          }
+        }
+        .getOrElseF {
+          liftFuture[F] {
+            Sync[F].delay {
+              fa(alg)
+            }
+          }
+        }
+
+    private def zipkinKernelToTraceId(kernel: Kernel): Option[TraceId] = {
+      val headers = kernel.toHeaders
+
+      headers.get("X-B3-SpanId")
+        .flatMap(SpanId.fromString)
+        .map { spanId =>
+          val traceId = headers.get("X-B3-TraceId").flatMap(SpanId.fromString)
+          val parentId = headers.get("X-B3-ParentSpanId").flatMap(SpanId.fromString)
+          val sampled = headers.get("X-B3-Sampled").collect {
+            case "1" => true
+          }
+
+          TraceId(traceId, parentId, spanId, sampled)
+        }
+    }
+  }
+}
+
+class TracedTwitterFutureAsyncFunctorK[F[_] : natchez.Trace] extends (Future ~~> F) {
+  override def asyncMapK[Alg[_[_]] : FunctorK](alg: Alg[Future])
+                                              (implicit AlgR: Alg[ReaderT[Future, Alg[Future], *]], F: Async[F]): Alg[F] =
+    AlgR.mapK(new ProvideFutureAlgWithTracing(alg))
+}

--- a/scalafix/output/src_managed/main/scala/example/thrift/SimpleService.scala
+++ b/scalafix/output/src_managed/main/scala/example/thrift/SimpleService.scala
@@ -751,7 +751,7 @@ object SimpleService extends _root_.com.twitter.finagle.thrift.GeneratedThriftSe
     implicit def SimpleServiceInReaderT[F[_]]: SimpleService[({type Λ[β0] = _root_.cats.data.ReaderT[F, SimpleService[F], β0]})#Λ] =
       _root_.cats.tagless.Derive.readerT[SimpleService, F]
 
-    implicit val SimpleServiceFunctorK: _root_.cats.tagless.FunctorK[SimpleService] = _root_.cats.tagless.Derive.functorK[SimpleService]
+    implicit val SimpleServiceInstrument: _root_.cats.tagless.aop.Instrument[SimpleService] = _root_.cats.tagless.Derive.instrument[SimpleService]
 
     implicit def SimpleServiceHigherKindedToMethodPerEndpoint: _root_.com.dwolla.util.async.finagle.HigherKindedToMethodPerEndpoint[SimpleService] =
       new _root_.com.dwolla.util.async.finagle.HigherKindedToMethodPerEndpoint[SimpleService] {

--- a/scalafix/rules/src/main/scala/com/dwolla/scrooge/scalafix/AddCatsTaglessInstances.scala
+++ b/scalafix/rules/src/main/scala/com/dwolla/scrooge/scalafix/AddCatsTaglessInstances.scala
@@ -78,7 +78,7 @@ case class ThriftServiceTrait(private val generatedThriftServiceObject: Defn.Obj
 
   private def allInstances: List[ImplicitInstance] = List(
     ImplicitInstance.AlgebraInKleisli(generatedThriftServiceObject.name.value),
-    ImplicitInstance.FunctorK(generatedThriftServiceObject.name.value),
+    ImplicitInstance.Instrument(generatedThriftServiceObject.name.value),
     ImplicitInstance.HigherKindedToMethodPerEndpoint(generatedThriftServiceObject.name.value),
   )
 
@@ -236,9 +236,10 @@ object ImplicitInstance {
          |""".stripMargin
   }
 
-  case class FunctorK(name: String) extends ImplicitInstance {
+  case class Instrument(name: String) extends ImplicitInstance {
+    // TODO make this Aspect[SimpleService, ToTraceValue, ToTraceValue]
     def code: String =
-      s"""    implicit val ${name}FunctorK: _root_.cats.tagless.FunctorK[$name] = _root_.cats.tagless.Derive.functorK[$name]
+      s"""    implicit val ${name}Instrument: _root_.cats.tagless.aop.Instrument[$name] = _root_.cats.tagless.Derive.instrument[$name]
          |""".stripMargin
   }
   
@@ -253,4 +254,3 @@ object ImplicitInstance {
          |""".stripMargin
   }
 }
-

--- a/scalafix/rules/src/test/scala/com/dwolla/scrooge/scalafix/AddCatsTaglessInstancesTest.scala
+++ b/scalafix/rules/src/test/scala/com/dwolla/scrooge/scalafix/AddCatsTaglessInstancesTest.scala
@@ -36,7 +36,7 @@ class AddCatsTaglessInstancesTest extends FunSuite {
        |    implicit def SimpleService2InReaderT[F[_]]: SimpleService2[({type Λ[β0] = _root_.cats.data.ReaderT[F, SimpleService2[F], β0]})#Λ] =
        |      _root_.cats.tagless.Derive.readerT[SimpleService2, F]
        |
-       |    implicit val SimpleService2FunctorK: _root_.cats.tagless.FunctorK[SimpleService2] = _root_.cats.tagless.Derive.functorK[SimpleService2]
+       |    implicit val SimpleService2Instrument: _root_.cats.tagless.aop.Instrument[SimpleService2] = _root_.cats.tagless.Derive.instrument[SimpleService2]
        |  }
        |
        |  trait MethodPerEndpoint extends SimpleService2[Future]
@@ -75,7 +75,7 @@ class AddCatsTaglessInstancesTest extends FunSuite {
         |    implicit def SimpleServiceInReaderT[F[_]]: SimpleService[({type Λ[β0] = _root_.cats.data.ReaderT[F, SimpleService[F], β0]})#Λ] =
         |      _root_.cats.tagless.Derive.readerT[SimpleService, F]
         |
-        |    implicit val SimpleServiceFunctorK: _root_.cats.tagless.FunctorK[SimpleService] = _root_.cats.tagless.Derive.functorK[SimpleService]
+        |    implicit val SimpleServiceInstrument: _root_.cats.tagless.aop.Instrument[SimpleService] = _root_.cats.tagless.Derive.instrument[SimpleService]
         |
         |    implicit def SimpleServiceHigherKindedToMethodPerEndpoint: _root_.com.dwolla.util.async.finagle.HigherKindedToMethodPerEndpoint[SimpleService] =
         |      new _root_.com.dwolla.util.async.finagle.HigherKindedToMethodPerEndpoint[SimpleService] {

--- a/twitter-finagle/src/main/scala/com/dwolla/util/async/finagle/HigherKindedToMethodPerEndpoint.scala
+++ b/twitter-finagle/src/main/scala/com/dwolla/util/async/finagle/HigherKindedToMethodPerEndpoint.scala
@@ -31,4 +31,15 @@ trait HigherKindedToMethodPerEndpoint[Alg[_[_]]] {
 
 object HigherKindedToMethodPerEndpoint {
   def apply[Alg[_[_]]](implicit hktmpe: HigherKindedToMethodPerEndpoint[Alg]): hktmpe.type = hktmpe
+
+  implicit def mpeClassTag[Alg[_[_]]](implicit MPE: HigherKindedToMethodPerEndpoint[Alg]): scala.reflect.ClassTag[MPE.MPE] =
+    MPE.mpeClassTag
+
+  implicit def toToMethodPerEndpointOps[Alg[_[_]]](alg: Alg[Future]): ToMethodPerEndpointOps[Alg] =
+    new ToMethodPerEndpointOps(alg)
+}
+
+class ToMethodPerEndpointOps[Alg[_[_]]](val alg: Alg[Future]) extends AnyVal {
+  def toMethodPerEndpoint(implicit HK2MPE: HigherKindedToMethodPerEndpoint[Alg]): HK2MPE.MPE =
+    HK2MPE.toMethodPerEndpoint(alg)
 }

--- a/twitter-finagle/src/main/scala/com/dwolla/util/async/finagle/ThriftClient.scala
+++ b/twitter-finagle/src/main/scala/com/dwolla/util/async/finagle/ThriftClient.scala
@@ -28,22 +28,25 @@ object ThriftClient {
                             FK: FunctorK[Alg],
                             MPE: HigherKindedToMethodPerEndpoint[Alg],
                            ): Resource[G, Alg[G]] = {
-      val acquire =
-        Sync[G].delay {
-          Thrift
-            .client
-            .withSessionPool.maxSize(config.sessionPoolMax)
-            .withRequestTimeout(config.requestTimeout)
-            .withSession.acquisitionTimeout(config.sessionAcquisitionTimeout)
-            .withTransport.connectTimeout(config.transportConnectTimeout)
-            .withRetryBudget(config.retryBudget)
-            .withTracer(config.tracer)
-            .build(dest)(HigherKindedToMethodPerEndpoint[Alg].mpeClassTag)
-        }
-          .map(_.asyncMapK[G])
+      val acquire = initialAcquire(dest, config).map(_.asyncMapK[G])
       val release: Alg[G] => G[Unit] = alg => liftFuture(Sync[G].delay(alg.asClosable.close()))
 
       Resource.make(acquire)(release)
     }
   }
+
+  private[finagle] def initialAcquire[Alg[_[_]], F[_] : Sync](dest: String,
+                                                              config: ThriftClientConfiguration)
+                                                             (implicit MPE: HigherKindedToMethodPerEndpoint[Alg]): F[MPE.MPE] =
+    Sync[F].delay {
+      Thrift
+        .client
+        .withSessionPool.maxSize(config.sessionPoolMax)
+        .withRequestTimeout(config.requestTimeout)
+        .withSession.acquisitionTimeout(config.sessionAcquisitionTimeout)
+        .withTransport.connectTimeout(config.transportConnectTimeout)
+        .withRetryBudget(config.retryBudget)
+        .withTracer(config.tracer)
+        .build[MPE.MPE](dest)(MPE.mpeClassTag)
+    }
 }

--- a/twitter-finagle/src/main/scala/com/dwolla/util/async/finagle/ThriftServer.scala
+++ b/twitter-finagle/src/main/scala/com/dwolla/util/async/finagle/ThriftServer.scala
@@ -3,7 +3,6 @@ package com.dwolla.util.async.finagle
 import cats._
 import cats.effect._
 import cats.effect.std.Dispatcher
-import cats.syntax.all._
 import cats.tagless._
 import cats.tagless.implicits._
 import com.dwolla.util.async.twitter._
@@ -17,7 +16,7 @@ object ThriftServer {
   def apply[F[_] : Async, Thrift[_[_]] : FunctorK : HigherKindedToMethodPerEndpoint](addr: String, iface: Thrift[F])
                                                                                     (implicit ec: ExecutionContext): Resource[F, ListeningServer] =
     Dispatcher.parallel[F]
-      .evalMap(unsafeMapKToFuture(_, iface).pure[F])
+      .map(unsafeMapKToFuture(_, iface))
       .flatMap(t => Resource.make(acquire[F, Thrift](addr, t))(release[F]))
 
   private def unsafeMapKToFuture[F[_], Thrift[_[_]] : FunctorK](dispatcher: Dispatcher[F], iface: Thrift[F])


### PR DESCRIPTION
`TracedThriftServer` will accept incoming requests with attached Zipkin trace IDs and provide them to a given Natchez `EntryPoint`.

`TracedThriftClient` builds a Finagle Thrift client in `G[_] : Async : Trace`, such that the trace provided by `Trace[G]` will be propagated into the Thrift requests made by the client using Finagle's built-in Zipkin support.