### PR TITLE
don't set crossScalaVersions in sbt-projectmatrix projects

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -13,6 +13,7 @@ pull_request_rules:
     - body~=labels:.*early-semver-patch
     - body~=labels:.*early-semver-minor
   - status-success=Build and Test (ubuntu-latest, 2.13, temurin@8)
+  - status-success=Validate Steward Config (ubuntu-latest, 2.13.6, temurin@11)
   actions:
     merge: {}
 - name: Label finagle-natchez PRs

--- a/build.sbt
+++ b/build.sbt
@@ -13,6 +13,7 @@ ThisBuild / startYear := Option(2021)
 ThisBuild / tlSonatypeUseLegacyHost := true
 ThisBuild / tlBaseVersion := "0.3"
 ThisBuild / tlCiReleaseBranches := Seq("main")
+ThisBuild / mergifyRequiredJobs ++= Seq("validate-steward")
 ThisBuild / mergifyStewardConfig ~= { _.map(_.copy(
   author = "dwolla-oss-scala-steward[bot]",
   mergeMinors = true,

--- a/project/AsyncUtilsTwitterPlugin.scala
+++ b/project/AsyncUtilsTwitterPlugin.scala
@@ -165,7 +165,6 @@ object AsyncUtilsTwitterPlugin extends AutoPlugin {
       Seq(
         publish / skip := true,
         publishArtifact := false,
-        crossScalaVersions := Scala2Versions,
         libraryDependencies ++= Seq(
           "com.twitter" %% "scrooge-core" % v.toString,
           "com.twitter" %% "finagle-thrift" % v.toString,
@@ -219,7 +218,6 @@ object AsyncUtilsTwitterPlugin extends AutoPlugin {
       Seq(
         publish / skip := true,
         publishArtifact := false,
-        crossScalaVersions := Scala2Versions,
         libraryDependencies ++= {
           Seq(
             "com.twitter" %% "util-core" % v.toString,


### PR DESCRIPTION
This should resolve the publish failure, which was caused by 2.13 projects being swapped into 2.12 mode and failing to resolve certain dependencies, and vice-versa.